### PR TITLE
HW 19 queue

### DIFF
--- a/Lesson_19-queue/1-Shortener/cmd/main.go
+++ b/Lesson_19-queue/1-Shortener/cmd/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"thinknetica_golang_core/Lesson_19-queue/1-Shortener/pkg/api"
+	"thinknetica_golang_core/Lesson_19-queue/1-Shortener/pkg/queue"
+
+	"github.com/gorilla/mux"
+)
+
+const (
+	queueConnectionString = "amqp://guest:guest@localhost:5672/"
+	queueName             = "UrlsApp"
+	webAddr               = ":8080"
+)
+
+func main() {
+	router := mux.NewRouter()
+	q, err := queue.New(queueConnectionString, queueName)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	// Не забываем закрывать ресурсы
+	defer q.Close()
+
+	api := api.New(router, q)
+	api.Endpoints()
+	http.ListenAndServe(webAddr, router)
+}

--- a/Lesson_19-queue/1-Shortener/cmd/main.go
+++ b/Lesson_19-queue/1-Shortener/cmd/main.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"thinknetica_golang_core/Lesson_19-queue/1-Shortener/pkg/api"
 	"thinknetica_golang_core/Lesson_19-queue/1-Shortener/pkg/queue"
+	"thinknetica_golang_core/Lesson_19-queue/1-Shortener/pkg/storage"
 
 	"github.com/gorilla/mux"
 )
@@ -17,15 +18,18 @@ const (
 
 func main() {
 	router := mux.NewRouter()
+	storage := storage.New()
 	q, err := queue.New(queueConnectionString, queueName)
 	if err != nil {
 		fmt.Println(err)
 		return
 	}
+	// обнуляем статистику при старте сервиса
+	q.PruneStat()
 	// Не забываем закрывать ресурсы
 	defer q.Close()
 
-	api := api.New(router, q)
+	api := api.New(router, q, storage)
 	api.Endpoints()
 	http.ListenAndServe(webAddr, router)
 }

--- a/Lesson_19-queue/1-Shortener/pkg/api/api.go
+++ b/Lesson_19-queue/1-Shortener/pkg/api/api.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"encoding/json"
+	"math/rand"
+	"net/http"
+	"sync"
+	"thinknetica_golang_core/Lesson_19-queue/1-Shortener/pkg/queue"
+	"time"
+
+	"github.com/gorilla/mux"
+)
+
+type API struct {
+	mu   sync.Mutex
+	data map[string]string
+
+	router *mux.Router
+	queue  *queue.Queue
+}
+
+// New создаёт объект API.
+func New(r *mux.Router, q *queue.Queue) *API {
+	rand.Seed(time.Now().UnixNano())
+	// обнуляем статистику при старте сервиса
+	q.PruneStat()
+
+	api := API{
+		router: r,
+		queue:  q,
+		data:   make(map[string]string),
+	}
+	return &api
+}
+
+// Endpoints регистрирует конечные точки API.
+func (api *API) Endpoints() {
+	api.router.HandleFunc("/api/v1/urls", api.urls).Methods(http.MethodGet, http.MethodOptions)
+	api.router.HandleFunc("/api/v1/url", api.newUrl).Methods(http.MethodPost, http.MethodOptions)
+	api.router.HandleFunc("/api/v1/urls/{key}", api.url).Methods(http.MethodGet, http.MethodOptions)
+}
+
+// Возвращает успешный ответ
+func responseOk(w http.ResponseWriter, v any, code int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	err := json.NewEncoder(w).Encode(v)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+// Возвращает сообщение об ошибке
+func responseErr(w http.ResponseWriter, code int, v any) {
+	w.WriteHeader(code)
+	if v != nil {
+		err := json.NewEncoder(w).Encode(v)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+}

--- a/Lesson_19-queue/1-Shortener/pkg/api/api.go
+++ b/Lesson_19-queue/1-Shortener/pkg/api/api.go
@@ -4,31 +4,28 @@ import (
 	"encoding/json"
 	"math/rand"
 	"net/http"
-	"sync"
 	"thinknetica_golang_core/Lesson_19-queue/1-Shortener/pkg/queue"
+	"thinknetica_golang_core/Lesson_19-queue/1-Shortener/pkg/storage"
 	"time"
 
 	"github.com/gorilla/mux"
 )
 
 type API struct {
-	mu   sync.Mutex
-	data map[string]string
-
-	router *mux.Router
-	queue  *queue.Queue
+	storage *storage.Storage
+	router  *mux.Router
+	queue   *queue.Queue
 }
 
 // New создаёт объект API.
-func New(r *mux.Router, q *queue.Queue) *API {
+func New(r *mux.Router, q *queue.Queue, s *storage.Storage) *API {
+	// тут или в storage ?
 	rand.Seed(time.Now().UnixNano())
-	// обнуляем статистику при старте сервиса
-	q.PruneStat()
 
 	api := API{
-		router: r,
-		queue:  q,
-		data:   make(map[string]string),
+		router:  r,
+		queue:   q,
+		storage: s,
 	}
 	return &api
 }

--- a/Lesson_19-queue/1-Shortener/pkg/api/urls.go
+++ b/Lesson_19-queue/1-Shortener/pkg/api/urls.go
@@ -1,0 +1,89 @@
+package api
+
+import (
+	"encoding/json"
+	"math"
+	"math/rand"
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+const (
+	// Набор символов короткого URL
+	shortChars = "abcdefghijklmnopqrstuvwxyz123456789"
+	// Длинна короткого URL
+	urlLen = 6
+)
+
+var (
+	// Максимально возможное число url для заданного набора чимволов и длинны короткой ссылки
+	// При использовании 9 цифр и 26 букы имеем для длинны 6
+	// (9+26)**6 = 1_838_265_625 (1.8 млрд) вариантов
+	maxUrls = int(math.Pow(float64(len([]byte(shortChars))), urlLen))
+)
+
+// Возвращает список всех пар сокращение - ссылка
+func (api *API) urls(w http.ResponseWriter, r *http.Request) {
+	api.mu.Lock()
+	defer api.mu.Unlock()
+
+	responseOk(w, api.data, http.StatusOK)
+}
+
+// Сохраняет новую ссылку и возвращает для нее сокращение
+func (api *API) newUrl(w http.ResponseWriter, r *http.Request) {
+	// Не создаем новую запись, если мы достигли предела по сохраненным уникальным комбинациям
+	if len(api.data) >= maxUrls {
+		responseErr(w, http.StatusInternalServerError, "To many urls in memory")
+	}
+
+	var d struct{ Url string }
+	err := json.NewDecoder(r.Body).Decode(&d)
+	if err != nil {
+		responseErr(w, http.StatusUnprocessableEntity, err.Error())
+		return
+	}
+
+	// Генерируем случайный ключ и проверяем, что он не занят.
+	// Если занят - повторяем заново
+	// Этот алгоритм явно будет работать тем медленнее, чем ближе мы к максимальному числу записей
+	shortUrl := ""
+	api.mu.Lock()
+	for {
+		shortUrl = randSeq(urlLen)
+		res := api.data[shortUrl]
+		if res == "" {
+			break
+		}
+	}
+	api.data[shortUrl] = d.Url
+	api.mu.Unlock()
+
+	api.queue.NewUrl(d.Url)
+
+	responseOk(w, shortUrl, http.StatusOK)
+}
+
+// Возвращает ссылку для данного сокращения
+func (api *API) url(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	key := vars["key"]
+	url := api.data[key]
+	if url == "" {
+		responseErr(w, http.StatusNotFound, nil)
+	}
+	// Переделал на Redirect
+	http.Redirect(w, r, url, http.StatusSeeOther)
+}
+
+// Генерирует случайную последовательность заданной динны из фиксированного набора символов
+func randSeq(n int) string {
+	letters := []rune(shortChars)
+
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}

--- a/Lesson_19-queue/1-Shortener/pkg/api/urls.go
+++ b/Lesson_19-queue/1-Shortener/pkg/api/urls.go
@@ -2,42 +2,18 @@ package api
 
 import (
 	"encoding/json"
-	"math"
-	"math/rand"
 	"net/http"
 
 	"github.com/gorilla/mux"
 )
 
-const (
-	// Набор символов короткого URL
-	shortChars = "abcdefghijklmnopqrstuvwxyz123456789"
-	// Длинна короткого URL
-	urlLen = 6
-)
-
-var (
-	// Максимально возможное число url для заданного набора чимволов и длинны короткой ссылки
-	// При использовании 9 цифр и 26 букы имеем для длинны 6
-	// (9+26)**6 = 1_838_265_625 (1.8 млрд) вариантов
-	maxUrls = int(math.Pow(float64(len([]byte(shortChars))), urlLen))
-)
-
 // Возвращает список всех пар сокращение - ссылка
 func (api *API) urls(w http.ResponseWriter, r *http.Request) {
-	api.mu.Lock()
-	defer api.mu.Unlock()
-
-	responseOk(w, api.data, http.StatusOK)
+	responseOk(w, api.storage.Urls(), http.StatusOK)
 }
 
 // Сохраняет новую ссылку и возвращает для нее сокращение
 func (api *API) newUrl(w http.ResponseWriter, r *http.Request) {
-	// Не создаем новую запись, если мы достигли предела по сохраненным уникальным комбинациям
-	if len(api.data) >= maxUrls {
-		responseErr(w, http.StatusInternalServerError, "To many urls in memory")
-	}
-
 	var d struct{ Url string }
 	err := json.NewDecoder(r.Body).Decode(&d)
 	if err != nil {
@@ -45,20 +21,11 @@ func (api *API) newUrl(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Генерируем случайный ключ и проверяем, что он не занят.
-	// Если занят - повторяем заново
-	// Этот алгоритм явно будет работать тем медленнее, чем ближе мы к максимальному числу записей
-	shortUrl := ""
-	api.mu.Lock()
-	for {
-		shortUrl = randSeq(urlLen)
-		res := api.data[shortUrl]
-		if res == "" {
-			break
-		}
+	shortUrl, err := api.storage.NewUrl(d.Url)
+	if err != nil {
+		responseErr(w, http.StatusUnprocessableEntity, err.Error())
+		return
 	}
-	api.data[shortUrl] = d.Url
-	api.mu.Unlock()
 
 	api.queue.NewUrl(d.Url)
 
@@ -69,21 +36,10 @@ func (api *API) newUrl(w http.ResponseWriter, r *http.Request) {
 func (api *API) url(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	key := vars["key"]
-	url := api.data[key]
+	url := api.storage.Url(key)
 	if url == "" {
 		responseErr(w, http.StatusNotFound, nil)
 	}
 	// Переделал на Redirect
 	http.Redirect(w, r, url, http.StatusSeeOther)
-}
-
-// Генерирует случайную последовательность заданной динны из фиксированного набора символов
-func randSeq(n int) string {
-	letters := []rune(shortChars)
-
-	b := make([]rune, n)
-	for i := range b {
-		b[i] = letters[rand.Intn(len(letters))]
-	}
-	return string(b)
 }

--- a/Lesson_19-queue/1-Shortener/pkg/queue/queue.go
+++ b/Lesson_19-queue/1-Shortener/pkg/queue/queue.go
@@ -1,0 +1,105 @@
+package queue
+
+import (
+	"encoding/json"
+	"log"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+type Queue struct {
+	conn *amqp.Connection
+	ch   *amqp.Channel
+	q    amqp.Queue
+}
+
+// Сообщение для обмена между сервисами Shortner и Analytics
+type Message struct {
+	Event string
+	Args  string
+}
+
+// Название эвентов поожим в константы
+const (
+	// Создание нового url
+	newUrl = "NewUrl"
+	// Обнулить статистику
+	pruneStat = "PruneStat"
+)
+
+// Подключается к очереди сообщений
+func New(cred string, name string) (*Queue, error) {
+	conn, err := amqp.Dial(cred)
+	if err != nil {
+		log.Println("Failed to connect to RabbitMQ", err)
+		return nil, err
+	}
+
+	ch, err := conn.Channel()
+	if err != nil {
+		log.Println("Failed to open a channel", err)
+		return nil, err
+	}
+
+	q, err := ch.QueueDeclare(
+		name,  // name
+		false, // durable
+		false, // delete when unused
+		false, // exclusive
+		false, // no-wait
+		nil,   // arguments
+	)
+	if err != nil {
+		log.Println("Failed to declare a queue", err)
+		return nil, err
+	}
+
+	queue := Queue{
+		conn: conn,
+		ch:   ch,
+		q:    q,
+	}
+	return &queue, nil
+}
+
+// Отправка в аналитику событие "Новый url"
+func (queue *Queue) NewUrl(url string) error {
+	m := Message{Event: newUrl, Args: url}
+	return queue.publish(m)
+}
+
+// Отправка в аналитику событие "Обнули статистику"
+func (queue *Queue) PruneStat() error {
+	m := Message{Event: pruneStat, Args: ""}
+	return queue.publish(m)
+}
+
+// Публикация события в очередь
+func (queue *Queue) publish(m Message) error {
+	body, err := json.Marshal(m)
+	if err != nil {
+		return err
+	}
+
+	err = queue.ch.Publish(
+		"",           // exchange
+		queue.q.Name, // routing key
+		false,        // mandatory
+		false,        // immediate
+		amqp.Publishing{
+			ContentType: "application/json",
+			Body:        body,
+		})
+	if err != nil {
+		return err
+	}
+
+	log.Printf(" [x] Sent %s\n", body)
+	return nil
+}
+
+// Функция закрывает открытые ресурсы
+func (queue *Queue) Close() {
+	queue.conn.Close()
+	queue.ch.Close()
+}

--- a/Lesson_19-queue/1-Shortener/pkg/storage/storage.go
+++ b/Lesson_19-queue/1-Shortener/pkg/storage/storage.go
@@ -1,0 +1,90 @@
+package storage
+
+import (
+	"errors"
+	"log"
+	"math"
+	"math/rand"
+	"sync"
+)
+
+type Urls map[string]string
+
+type Storage struct {
+	mu   sync.Mutex
+	data Urls
+}
+
+const (
+	// Набор символов короткого URL
+	shortChars = "abcdefghijklmnopqrstuvwxyz123456789"
+	// Длинна короткого URL
+	urlLen = 6
+)
+
+var (
+	// Максимально возможное число url для заданного набора чимволов и длинны короткой ссылки
+	// При использовании 9 цифр и 26 букы имеем для длинны 6
+	// (9+26)**6 = 1_838_265_625 (1.8 млрд) вариантов
+	maxUrls = int(math.Pow(float64(len([]byte(shortChars))), urlLen))
+)
+
+func New() *Storage {
+	s := Storage{
+		data: make(map[string]string),
+	}
+	log.Println("Started storage with", s.data)
+	return &s
+}
+
+// Возвращает статистику
+func (s *Storage) Urls() Urls {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.data
+}
+
+func (s *Storage) NewUrl(url string) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Не создаем новую запись, если мы достигли предела по сохраненным уникальным комбинациям
+	if len(s.data) >= maxUrls {
+		err := errors.New("To many urls in memory")
+		return "", err
+	}
+
+	// Генерируем случайный ключ и проверяем, что он не занят.
+	// Если занят - повторяем заново
+	// Этот алгоритм явно будет работать тем медленнее, чем ближе мы к максимальному числу записей
+	shortUrl := ""
+	for {
+		shortUrl = randSeq(urlLen)
+		res := s.data[shortUrl]
+		if res == "" {
+			break
+		}
+	}
+	s.data[shortUrl] = url
+
+	return shortUrl, nil
+}
+
+func (s *Storage) Url(shortUrl string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.data[shortUrl]
+}
+
+// Генерирует случайную последовательность заданной динны из фиксированного набора символов
+func randSeq(n int) string {
+	letters := []rune(shortChars)
+
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letters[rand.Intn(len(letters))]
+	}
+	return string(b)
+}

--- a/Lesson_19-queue/2-Analytics/pkg/api/api.go
+++ b/Lesson_19-queue/2-Analytics/pkg/api/api.go
@@ -1,0 +1,55 @@
+package api
+
+import (
+	"encoding/json"
+	"math/rand"
+	"net/http"
+	"thinknetica_golang_core/Lesson_19-queue/2-Analytics/pkg/queue"
+	"thinknetica_golang_core/Lesson_19-queue/2-Analytics/pkg/storage"
+
+	"time"
+
+	"github.com/gorilla/mux"
+)
+
+type API struct {
+	router  *mux.Router
+	queue   *queue.Queue
+	storage *storage.Storage
+}
+
+// New создаёт объект API.
+func New(r *mux.Router, q *queue.Queue, s *storage.Storage) *API {
+	rand.Seed(time.Now().UnixNano())
+
+	api := API{
+		router:  r,
+		queue:   q,
+		storage: s,
+	}
+	return &api
+}
+
+// Endpoints регистрирует конечные точки API.
+func (api *API) Endpoints() {
+	api.router.HandleFunc("/api/v1/stat", api.stat).Methods(http.MethodGet, http.MethodOptions)
+}
+
+// Возвращает успешный ответ
+func responseOk(w http.ResponseWriter, v []byte, code int) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	w.Write(v)
+}
+
+// Возвращает сообщение об ошибке
+func responseErr(w http.ResponseWriter, code int, v any) {
+	w.WriteHeader(code)
+	if v != nil {
+		err := json.NewEncoder(w).Encode(v)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+}

--- a/Lesson_19-queue/2-Analytics/pkg/api/stat.go
+++ b/Lesson_19-queue/2-Analytics/pkg/api/stat.go
@@ -1,0 +1,16 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// Возвращает статистику
+func (api *API) stat(w http.ResponseWriter, r *http.Request) {
+	data := api.storage.Stat()
+	body, err := json.Marshal(data)
+	if err != nil {
+		responseErr(w, http.StatusUnprocessableEntity, err)
+	}
+	responseOk(w, body, http.StatusOK)
+}

--- a/Lesson_19-queue/2-Analytics/pkg/queue/queue.go
+++ b/Lesson_19-queue/2-Analytics/pkg/queue/queue.go
@@ -1,0 +1,120 @@
+package queue
+
+import (
+	"encoding/json"
+	"log"
+	"sync"
+	"thinknetica_golang_core/Lesson_19-queue/2-Analytics/pkg/storage"
+
+	amqp "github.com/rabbitmq/amqp091-go"
+)
+
+type Queue struct {
+	conn    *amqp.Connection
+	ch      *amqp.Channel
+	q       amqp.Queue
+	storage *storage.Storage
+}
+
+// Сообщение для обмена между сервисами Shortner и Analytics
+type Message struct {
+	Event string
+	Args  string
+}
+
+// Название эвентов поожим в константы
+const (
+	// Создание нового url
+	newUrl = "NewUrl"
+	// Обнулить статистику
+	pruneStat = "PruneStat"
+)
+
+// Подключается к очереди сообщений
+func New(cred string, name string, s *storage.Storage) (*Queue, error) {
+	conn, err := amqp.Dial(cred)
+	if err != nil {
+		log.Println("Failed to connect to RabbitMQ", err)
+		return nil, err
+	}
+
+	ch, err := conn.Channel()
+	if err != nil {
+		log.Println("Failed to open a channel", err)
+		return nil, err
+	}
+
+	q, err := ch.QueueDeclare(
+		name,  // name
+		false, // durable
+		false, // delete when unused
+		false, // exclusive
+		false, // no-wait
+		nil,   // arguments
+	)
+	if err != nil {
+		log.Println("Failed to declare a queue", err)
+		return nil, err
+	}
+
+	queue := Queue{
+		conn:    conn,
+		ch:      ch,
+		q:       q,
+		storage: s,
+	}
+	return &queue, nil
+}
+
+// Запуск прослушивания очереди
+func (queue *Queue) Consume() error {
+	msgs, err := queue.ch.Consume(
+		queue.q.Name, // queue
+		"",           // consumer
+		true,         // auto-ack
+		false,        // exclusive
+		false,        // no-local
+		false,        // no-wait
+		nil,          // args
+	)
+	if err != nil {
+		log.Println("Failed to declare a queue", err)
+		return err
+	}
+
+	var wg sync.WaitGroup
+	var m Message
+
+	wg.Add(1)
+	go func() {
+		for d := range msgs {
+			log.Printf("Received a message: %s", d.Body)
+			err := json.Unmarshal(d.Body, &m)
+			if err == nil {
+				queue.handleEvent(m)
+			}
+		}
+	}()
+
+	log.Printf(" [*] Waiting for messages. To exit press CTRL+C")
+	wg.Wait()
+	return nil
+}
+
+// Обработчик для входящих эвентов
+func (queue *Queue) handleEvent(m Message) {
+	switch m.Event {
+	case newUrl:
+		queue.storage.NewUrlHandler(m.Args)
+	case pruneStat:
+		queue.storage.PruneStatHandler()
+	default:
+		log.Printf("Unknown event %v", m.Event)
+	}
+}
+
+// Функция закрывает открытые ресурсы
+func (queue *Queue) Close() {
+	queue.conn.Close()
+	queue.ch.Close()
+}

--- a/Lesson_19-queue/2-Analytics/pkg/storage/storage.go
+++ b/Lesson_19-queue/2-Analytics/pkg/storage/storage.go
@@ -1,0 +1,83 @@
+package storage
+
+import (
+	"log"
+	"sync"
+)
+
+type Storage struct {
+	mu   sync.Mutex
+	data Stat
+	urls []string
+}
+
+// Структура для кранения статистики
+type Stat struct {
+	UrlsCount int32 `json:"urlsCount"`
+	MaxUrlLen int   `json:"maxUrlLen"`
+	AvgUrlLen int   `json:"avgUrlLen"`
+}
+
+func New() *Storage {
+	s := Storage{
+		data: Stat{
+			UrlsCount: 0,
+			MaxUrlLen: 0,
+			AvgUrlLen: 0,
+		},
+		urls: make([]string, 0),
+	}
+	log.Println("Started storage with", s.data)
+	return &s
+}
+
+// Возвращает статистику
+func (s *Storage) Stat() Stat {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.data
+}
+
+// Обработчик события "Новый url"
+func (s *Storage) NewUrlHandler(url string) Stat {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	data := s.data
+	data.UrlsCount = data.UrlsCount + 1
+	s.urls = append(s.urls, url)
+
+	t := 0
+	max := 0
+	for _, str := range s.urls {
+		l := len([]rune(str))
+		t = t + l
+		if l > max {
+			max = l
+		}
+	}
+	avg := t / len(s.urls)
+
+	data.AvgUrlLen = avg
+	data.MaxUrlLen = max
+
+	s.data = data
+	return s.data
+}
+
+// Обработчик события "Очистить статистику"
+func (s *Storage) PruneStatHandler() Stat {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	stat := Stat{
+		UrlsCount: 0,
+		MaxUrlLen: 0,
+		AvgUrlLen: 0,
+	}
+
+	s.data = stat
+	s.urls = make([]string, 0)
+	return s.data
+}

--- a/Lesson_19-queue/rabbitmq_start.sh
+++ b/Lesson_19-queue/rabbitmq_start.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+docker run -it --rm --name rabbitmq -p 5672:5672 -p 15672:15672 rabbitmq:3.10-management

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b // indirect
 	github.com/jackc/pgtype v1.11.0 // indirect
 	github.com/jackc/puddle v1.2.1 // indirect
+	github.com/rabbitmq/amqp091-go v1.3.4 // indirect
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e // indirect
 	golang.org/x/sys v0.0.0-20220608164250-635b8c9b7f68 // indirect
 	golang.org/x/text v0.3.7 // indirect


### PR DESCRIPTION
- В качестве очереди выбран RabbitMQ 
- Сервис Аналитики может обрабатывать два события "Добавлен новый url" и "Очистить статистику"
- Сервис Аналитики считает: число сохраненных url, максимальную и среднюю длинну url
- Исправлено поведение сервиса Shortener. Теперь он переадресует на полную ссылку при заходе на короткую
- исправлено объявление мьютекса согласно рекомендациям из прошлых PR